### PR TITLE
launch: keep all namespaces relative

### DIFF
--- a/launch/state_machine_bringup.launch
+++ b/launch/state_machine_bringup.launch
@@ -1,8 +1,8 @@
 <launch>
     <arg name="egm_settings" default="" doc="The filename (including path) of the file containing the EGM settings to apply for each EGM session." />
     <arg name="taskname" default="T_ROB1" doc="The name of the RAPID task which is running the 'StateMachine Add-In'" />
-    <arg name="rws_namespace" default="/rws" doc="Namespace of the RWS services and topics to be used by the state machine" />
-    <arg name="egm_namespace" default="/egm" doc="Namespace of the EGM services and topics to be used by the state machine" />
+    <arg name="rws_namespace" default="rws" doc="Namespace of the RWS services and topics to be used by the state machine" />
+    <arg name="egm_namespace" default="egm" doc="Namespace of the EGM services and topics to be used by the state machine" />
     
     <param name="egm_settings" value="$(arg egm_settings)"/>
     <param name="taskname" value="$(arg taskname)"/>


### PR DESCRIPTION
As per title.

Otherwise pushing the nodes/launch file in a namespace itself is complicated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated default values for certain launch arguments by removing leading slashes from their namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->